### PR TITLE
fix(ReadRTF): 某些情况下 `DEL_RTF_CTRL` 不生效

### DIFF
--- a/gbk/ReadRTF.sas
+++ b/gbk/ReadRTF.sas
@@ -332,7 +332,7 @@ options cmplib = sasuser.func;
         %let reg_ctrl_3 = %bquote(\\nosupersub);
 
         /*¿ØÖÆ×Ö-ÉÏ±ê*/
-        %let reg_ctrl_4 = %bquote(\{?\\super\s+((?:\\[\\\{\}]|[^\\\{\}])+)\}?); /*
+        %let reg_ctrl_4 = %bquote(\{?\\super\s*((?:\\[\\\{\}]|[^\\\{\}])+)\}?); /*
                                                                                https://github.com/Snoopy1866/RTFTools-For-SAS/issues/20
                                                                                https://github.com/Snoopy1866/RTFTools-For-SAS/issues/26
                                                                               */


### PR DESCRIPTION
对比以下两个正则表达式：
1. https://jianyu.io/regulex/#!flags=&re=%5C%7B%3F%5C%5Csuper%5Cs*((%3F%3A%5C%5C%5B%5C%5C%5C%7B%5C%7D%5D%7C%5B%5E%5C%5C%5C%7B%5C%7D%5D)%2B)%5C%7D%3F

   ```
   \{?\\super\s*((?:\\[\\\{\}]|[^\\\{\}])+)\}?
   ```

2. https://jianyu.io/regulex/#!flags=&re=%5C%7B%3F%5C%5Csuper%5Cs%2B((%3F%3A%5C%5C%5B%5C%5C%5C%7B%5C%7D%5D%7C%5B%5E%5C%5C%5C%7B%5C%7D%5D)%2B)%5C%7D%3F

   ```
   \{?\\super\s+((?:\\[\\\{\}]|[^\\\{\}])+)\}?
   ```

对于某个 RTF 段落 `\'CC\'DE\'B3\'FD{\super [3]}, n(%){\super [4]}\cell}`，前者可以正常匹配，后者无法匹配。
